### PR TITLE
draft of manage_study.py setup for testing

### DIFF
--- a/docs/metadata_validation.md
+++ b/docs/metadata_validation.md
@@ -1,0 +1,18 @@
+Install Single Cell Portal convenience scripts:
+
+```
+git clone https://github.com/broadinstitute/single_cell_portal.git
+cd single_cell_portal
+python3 -m venv env --copies
+source env/bin/activate
+pip install -r requirements.txt
+```
+
+Then [install and initialize Google Cloud SDK](https://cloud.google.com/sdk/docs/quickstarts) on your machine.
+
+Testing manage_study.py
+```
+cd scripts
+ACCESS_TOKEN=`gcloud auth print-access-token`
+python manage_study.py --token=$ACCESS_TOKEN list-studies --summary
+```


### PR DESCRIPTION
@jggatter sending a pull request so we try out using readthedocs for collaborative content editing, this generic setup info will go to the SCP wiki.

Until ingest pipeline is put in production, the other manage_study options will likely fail so please don't experiment with manage_study.py for now. Thanks!